### PR TITLE
Fix Next.js build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ vite.config.ts
 node_modules
 dist
 dist-ssr
+.next
 # Ignore local environment overrides
 *.local
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ npm install
 npm run dev
 ```
 
+Build the Next.js app for production:
+
+```bash
+npm run build
+```
+
 Create a `.env.local` file with your Upstash credentials (see `.env.example`):
 
 ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "node server.js"
+    "dev": "node server.js",
+    "build": "next build"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
   "dependencies": {
     "@upstash/redis": "^1.35.0",
     "express": "^4.21.2",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
- remove `type: commonjs` to allow Next.js build to parse ES modules

## Testing
- `npx next build`

------
https://chatgpt.com/codex/tasks/task_e_685d665ea60083339dfe173fa65952cc